### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ addopts = -s
 [testenv]
 passenv=EASY_CACHE_REDIS_HOST,EASY_CACHE_MEMCACHED_HOST
 commands=
-    py.test tests/tests_basic.py
-    py.test tests/tests_cache_clients.py
+    pytest tests/tests_basic.py
+    pytest tests/tests_cache_clients.py
     python tests/benchmarks.py
 setenv =
     EASY_CACHE_LAZY_MODE_ENABLE = yes


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot